### PR TITLE
Remove explicit commit, it doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Run [OpsWorks](http://aws.amazon.com/opsworks/) deployments from
 - `app-id` (required) OpsWorks app ID.
 - `region` (optional, default `us-east-1`) AWS region.
 - `migrate` (optional, default `false`) Whether to run migrations.
-- `comment` (optional, default `Deploy commit $WERCKER_GIT_COMMIT by
-  $WERCKER_STARTED_BY from Wercker.`) Comment for the deployment.
+- `comment` (optional, default `Wercker deploy by $WERCKER_STARTED_BY:
+  $WERCKER_DEPLOY_URL.`) Comment for the deployment.
 
 ## Example
 

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ else
 fi
 
 if [ ! -n "$WERCKER_OPSWORKS_DEPLOY_COMMENT" ]; then
-    export DEPLOY_COMMENT="Deploy commit $WERCKER_GIT_COMMIT by $WERCKER_STARTED_BY from Wercker.";
+    export DEPLOY_COMMENT="Wercker deploy by $WERCKER_STARTED_BY: $WERCKER_DEPLOY_URL";
 else
     export DEPLOY_COMMENT="$WERCKER_OPSWORKS_DEPLOY_COMMENT";
 fi
@@ -64,12 +64,5 @@ aws opsworks create-deployment \
       \"Name\": \"deploy\",
       \"Args\": {
         \"migrate\": [\"$AWS_OPSWORKS_MIGRATE\"]
-      }
-    }" \
-    --custom-json "{
-      \"deploy\": {
-        \"scm\": {
-          \"revision\": \"$WERCKER_GIT_COMMIT\"
-        }
       }
     }";


### PR DESCRIPTION
Commit hashes need to be passed in as the `['deploy'][app_short_name]['scm']['revision']` attribute, so the app short name will have to be retrieved before the deploy is started. For now, this just removes it to avoid confusion.
