### PR TITLE
Use a default comment that doesn't explode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Run [OpsWorks](http://aws.amazon.com/opsworks/) deployments from
 - `app-id` (required) OpsWorks app ID.
 - `region` (optional, default `us-east-1`) AWS region.
 - `migrate` (optional, default `false`) Whether to run migrations.
-- `comment` (optional, default `Wercker deploy by $WERCKER_STARTED_BY:
-  $WERCKER_DEPLOY_URL.`) Comment for the deployment.
+- `comment` (optional, default `Wercker deploy by $WERCKER_STARTED_BY.`)
+  Comment for the deployment.
 
 ## Example
 

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ else
 fi
 
 if [ ! -n "$WERCKER_OPSWORKS_DEPLOY_COMMENT" ]; then
-    export DEPLOY_COMMENT="Wercker deploy by $WERCKER_STARTED_BY: $WERCKER_DEPLOY_URL";
+    export DEPLOY_COMMENT="Wercker deploy by $WERCKER_STARTED_BY.";
 else
     export DEPLOY_COMMENT="$WERCKER_OPSWORKS_DEPLOY_COMMENT";
 fi


### PR DESCRIPTION
Putting the Wercker deploy URL in the comment apparently doesn't work.
