### PR TITLE
Migrate takes an array for some reason?

### DIFF
--- a/lib/deployer/opsworks.js
+++ b/lib/deployer/opsworks.js
@@ -67,7 +67,7 @@ OpsWorksDeployer.prototype.deploy = function(options, callback) {
     Command: {
       Name: 'deploy',
       Args: {
-        'migrate': options.migrate
+        'migrate': [options.migrate]
       },
     },
     StackId: options.stackId,

--- a/test/deployer/test_opsworks.js
+++ b/test/deployer/test_opsworks.js
@@ -173,7 +173,7 @@ describe('OpsWorksDeployer', function() {
         Command: {
           Name: 'deploy',
           Args: {
-            'migrate': 'true',
+            'migrate': ['true'],
           },
         },
         StackId: 'stack-id',


### PR DESCRIPTION
This fixes an issue where the deploy fails because the migrate argument needs to be sent to OpsWorks as an array, which is just silly.
