### PR TITLE
Use sudo to globally install dropper

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ sudo apt-get update -y;
 sudo apt-get install nodejs -y;
 
 info 'Installing the CLI...';
-npm install -g dropper@1.0.x
+sudo npm install -g dropper@1.0.x
 
 info 'Deploying...';
 dropper opsworks \


### PR DESCRIPTION
Not using sudo to install dropper caused a permission error. Whoops!!!!
