### PR TITLE
Deploy the current commit

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -57,4 +57,5 @@ dropper opsworks \
     --region $AWS_DEFAULT_REGION \
     $AWS_OPSWORKS_MIGRATE \
     $AWS_OPSWORKS_WAIT_FOR_DEPLOY \
+    --revision $WERCKER_GIT_COMMIT \
     --comment "$DEPLOY_COMMENT";

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -162,3 +162,9 @@ teardown() {
 
     assert_dropper_arg not '--wait-for-deploy'
 }
+
+@test 'the current commit should be deployed' {
+    WERCKER_GIT_COMMIT='git-commit-hash-123' run ./deploy.sh
+
+    assert_dropper_arg '--revision git-commit-hash-123'
+}


### PR DESCRIPTION
This deploys the currently checked out commit, ensuring the exact version being built is deployed.

Resolves #9.
