### PR TITLE
Fix paths to bash scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-./install.sh
-./deploy.sh
+$WERCKER_STEP_ROOT/install.sh
+$WERCKER_STEP_ROOT/deploy.sh


### PR DESCRIPTION
This uses the correct? (hopefully?) paths to the install and deploy scripts.
