### PR TITLE
Use the source

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-set -e
-
-$WERCKER_STEP_ROOT/install.sh
-$WERCKER_STEP_ROOT/deploy.sh
+source $WERCKER_STEP_ROOT/install.sh
+source $WERCKER_STEP_ROOT/deploy.sh


### PR DESCRIPTION
This addresses an issue brought up in #17, where the `info`, `error`, etc. functions provided by Wercker aren't available in `install.sh` or `deploy.sh`.